### PR TITLE
Add moderator chat configuration and dispatcher support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Environment variables for the user bot platform.
+#
+# Copy this file to `.env` and fill in the values before running the
+# application locally. Secrets should never be committed to version control.
+
+# Telegram bot token used to authenticate requests against the Telegram Bot API.
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+
+# Primary chat identifier for moderator alerts (e.g., Telegram group chat ID).
+# Set this to the numeric chat ID that should receive moderation updates.
+MODERATOR_CHAT_ID=123456789
+
+# Optional comma-separated list of additional administrator chat IDs that should
+# receive escalation messages together with the moderator chat.
+ADMIN_CHAT_IDS=987654321,123456780

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# User Bot Platform
+
+This repository contains a small example of a Telegram bot platform. The
+application is configured via environment variables and exposes utilities for
+sending moderation alerts to pre-defined chats.
+
+## Configuration
+
+Copy the `.env.example` file to `.env` and adjust the variables to match your
+Telegram setup. The following variables are currently supported:
+
+- `TELEGRAM_BOT_TOKEN` – Token obtained from [@BotFather](https://t.me/BotFather).
+- `MODERATOR_CHAT_ID` – Numeric chat identifier that should receive moderator
+  notifications (can point to a group or private chat).
+- `ADMIN_CHAT_IDS` – Optional comma-separated list of additional chats that
+  should receive escalation messages together with the moderator chat.
+
+When the application starts, `bot_platform.config.Settings` reads these values
+and makes them available via convenient helpers, such as
+`Settings.moderation_chat_ids`. Telegram integration helpers (see
+`bot_platform/telegram/dispatcher.py`) automatically forward moderation alerts
+from the dispatcher to all configured chats.

--- a/bot_platform/__init__.py
+++ b/bot_platform/__init__.py
@@ -1,0 +1,5 @@
+"""Core package for the user bot platform."""
+
+from .config import Settings, get_settings
+
+__all__ = ["Settings", "get_settings"]

--- a/bot_platform/config.py
+++ b/bot_platform/config.py
@@ -1,0 +1,65 @@
+"""Application configuration and settings management."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Iterable, List, Optional
+
+from pydantic import BaseSettings, Field, validator
+
+
+class Settings(BaseSettings):
+    """Runtime configuration loaded from environment variables."""
+
+    telegram_bot_token: str = Field(..., env="TELEGRAM_BOT_TOKEN")
+    moderator_chat_id: Optional[int] = Field(None, env="MODERATOR_CHAT_ID")
+    admin_chat_ids: List[int] = Field(default_factory=list, env="ADMIN_CHAT_IDS")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+    @validator("moderator_chat_id", pre=True)
+    def _validate_moderator_chat_id(cls, value: Optional[str]) -> Optional[int]:
+        """Convert the moderator chat id to an integer when provided."""
+
+        if value in (None, ""):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError("MODERATOR_CHAT_ID must be an integer") from exc
+
+    @validator("admin_chat_ids", pre=True)
+    def _parse_admin_chat_ids(cls, value: Optional[Iterable[int]]) -> List[int]:
+        """Normalise the administrator chat identifiers into a list of ints."""
+
+        if value in (None, "", []):
+            return []
+        if isinstance(value, str):
+            items = [item.strip() for item in value.split(",") if item.strip()]
+            return [int(item) for item in items]
+        return [int(item) for item in value]
+
+    @property
+    def moderation_chat_ids(self) -> List[int]:
+        """Return the combined list of moderator and admin chat IDs."""
+
+        ids: List[int] = []
+        if self.moderator_chat_id is not None:
+            ids.append(self.moderator_chat_id)
+        ids.extend(self.admin_chat_ids)
+        # preserve order while removing duplicates
+        seen = set()
+        unique_ids: List[int] = []
+        for chat_id in ids:
+            if chat_id not in seen:
+                seen.add(chat_id)
+                unique_ids.append(chat_id)
+        return unique_ids
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return cached application settings."""
+
+    return Settings()

--- a/bot_platform/telegram/__init__.py
+++ b/bot_platform/telegram/__init__.py
@@ -1,0 +1,5 @@
+"""Telegram integration helpers for the user bot platform."""
+
+from .dispatcher import ModerationDispatcher, TelegramBotProtocol
+
+__all__ = ["ModerationDispatcher", "TelegramBotProtocol"]

--- a/bot_platform/telegram/dispatcher.py
+++ b/bot_platform/telegram/dispatcher.py
@@ -1,0 +1,33 @@
+"""Telegram dispatcher utilities that are aware of moderator chat IDs."""
+from __future__ import annotations
+
+from typing import Iterable, Protocol
+
+from bot_platform.config import Settings
+
+
+class TelegramBotProtocol(Protocol):
+    """Simplified protocol representing the interface used by the dispatcher."""
+
+    def send_message(self, chat_id: int, text: str, **kwargs: object) -> None:
+        """Send a message to the given chat."""
+
+
+class ModerationDispatcher:
+    """Dispatches Telegram messages to moderators configured in settings."""
+
+    def __init__(self, bot: TelegramBotProtocol, settings: Settings) -> None:
+        self._bot = bot
+        self._settings = settings
+
+    @property
+    def moderation_targets(self) -> Iterable[int]:
+        """Return the list of chat IDs used for moderation notifications."""
+
+        return self._settings.moderation_chat_ids
+
+    def notify_moderators(self, text: str, **kwargs: object) -> None:
+        """Send a notification message to all moderation chats."""
+
+        for chat_id in self.moderation_targets:
+            self._bot.send_message(chat_id=chat_id, text=text, **kwargs)


### PR DESCRIPTION
## Summary
- add moderator and admin chat identifiers to the sample environment file
- expose the moderator chat configuration via the settings module and dispatcher helper
- document how to configure moderator chats in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d677f8d6788327b4daa05b38664189