### PR TITLE
Refine moderation chat configuration parsing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Environment variables for the user bot platform.
+#
+# Copy this file to `.env` and fill in the values before running the
+# application locally. Secrets should never be committed to version control.
+
+# Telegram bot token used to authenticate requests against the Telegram Bot API.
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+
+# Primary chat identifier for moderator alerts (e.g., Telegram group chat ID).
+# Set this to the single numeric chat ID that should receive moderation updates.
+# Leave empty to disable automatic moderator notifications.
+MODERATOR_CHAT_ID=123456789
+
+# Optional list of additional administrator chat IDs that should receive
+# escalation messages together with the moderator chat. Values can be separated
+# by commas or whitespace, must be numeric, and duplicates are removed
+# automatically.
+ADMIN_CHAT_IDS=987654321,123456780

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# User Bot Platform
+
+This repository contains a small example of a Telegram bot platform. The
+application is configured via environment variables and exposes utilities for
+sending moderation alerts to pre-defined chats.
+
+## Configuration
+
+Copy the `.env.example` file to `.env` and adjust the variables to match your
+Telegram setup. The following variables are currently supported:
+
+- `TELEGRAM_BOT_TOKEN` – Token obtained from [@BotFather](https://t.me/BotFather).
+- `MODERATOR_CHAT_ID` – Numeric chat identifier that should receive moderator
+  notifications (can point to a group or private chat). Provide a single value;
+  specifying more than one identifier triggers a configuration error. Leave the
+  variable empty to disable automatic moderator notifications.
+- `ADMIN_CHAT_IDS` – Optional list of additional chats that should receive
+  escalation messages together with the moderator chat. Identifiers can be
+  separated by commas or whitespace, must be numeric, and are deduplicated
+  before dispatching notifications.
+
+When the application starts, `bot_platform.config.Settings` reads these values
+and makes them available via convenient helpers, such as
+`Settings.moderation_chat_ids`. Telegram integration helpers (see
+`bot_platform/telegram/dispatcher.py`) automatically forward moderation alerts
+from the dispatcher to all configured chats.

--- a/bot_platform/__init__.py
+++ b/bot_platform/__init__.py
@@ -1,0 +1,5 @@
+"""Core package for the user bot platform."""
+
+from .config import Settings, get_settings
+
+__all__ = ["Settings", "get_settings"]

--- a/bot_platform/config.py
+++ b/bot_platform/config.py
@@ -1,0 +1,118 @@
+"""Application configuration and settings management."""
+from __future__ import annotations
+
+from collections.abc import Iterable as IterableABC
+from functools import lru_cache
+from itertools import chain
+import re
+from typing import Iterable, Iterator, List, Optional, Sequence
+
+from pydantic import BaseSettings, Field, validator
+
+
+class Settings(BaseSettings):
+    """Runtime configuration loaded from environment variables."""
+
+    telegram_bot_token: str = Field(..., env="TELEGRAM_BOT_TOKEN")
+    moderator_chat_id: Optional[int] = Field(None, env="MODERATOR_CHAT_ID")
+    admin_chat_ids: List[int] = Field(default_factory=list, env="ADMIN_CHAT_IDS")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+    @validator("moderator_chat_id", pre=True)
+    def _validate_moderator_chat_id(cls, value: object) -> Optional[int]:
+        """Normalise the moderator chat id to a single integer when provided."""
+
+        chat_ids = cls._parse_chat_id_list(
+            value,
+            field_name="MODERATOR_CHAT_ID",
+            allow_multiple=False,
+        )
+        return chat_ids[0] if chat_ids else None
+
+    @validator("admin_chat_ids", pre=True)
+    def _parse_admin_chat_ids(cls, value: object) -> List[int]:
+        """Normalise the administrator chat identifiers into a list of ints."""
+
+        return cls._parse_chat_id_list(
+            value,
+            field_name="ADMIN_CHAT_IDS",
+            allow_multiple=True,
+        )
+
+    @property
+    def moderation_chat_ids(self) -> Sequence[int]:
+        """Return the combined list of moderator and admin chat IDs."""
+
+        combined = chain(
+            (self.moderator_chat_id,)
+            if self.moderator_chat_id is not None
+            else (),
+            self.admin_chat_ids,
+        )
+        return tuple(self._deduplicate(combined))
+
+    @staticmethod
+    def _deduplicate(ids: Iterable[int]) -> List[int]:
+        """Remove duplicates while preserving the original order."""
+
+        seen = set()
+        unique_ids: List[int] = []
+        for chat_id in ids:
+            if chat_id not in seen:
+                seen.add(chat_id)
+                unique_ids.append(chat_id)
+        return unique_ids
+
+    @classmethod
+    def _parse_chat_id_list(
+        cls,
+        value: object,
+        *,
+        field_name: str,
+        allow_multiple: bool,
+    ) -> List[int]:
+        """Parse chat identifier data from environment input."""
+
+        items: List[int] = []
+        for raw_value in cls._iter_chat_id_values(value):
+            try:
+                items.append(int(str(raw_value).strip()))
+            except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+                raise ValueError(
+                    f"{field_name} must contain integer values"
+                ) from exc
+
+        if not items:
+            return []
+        if not allow_multiple and len(items) > 1:
+            raise ValueError(
+                f"{field_name} must contain exactly one chat identifier"
+            )
+
+        return cls._deduplicate(items)
+
+    @staticmethod
+    def _iter_chat_id_values(value: object) -> Iterator[object]:
+        """Yield raw chat identifier values from diverse environment inputs."""
+
+        if value in (None, "", [], ()):  # support blank env variables
+            return iter(())
+
+        if isinstance(value, str):
+            segments = re.split(r"[,\s]+", value.strip())
+            return (segment for segment in segments if segment)
+
+        if isinstance(value, IterableABC):
+            return (item for item in value if item not in (None, ""))
+
+        return iter((value,))
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return cached application settings."""
+
+    return Settings()

--- a/bot_platform/telegram/__init__.py
+++ b/bot_platform/telegram/__init__.py
@@ -1,0 +1,5 @@
+"""Telegram integration helpers for the user bot platform."""
+
+from .dispatcher import ModerationDispatcher, TelegramBotProtocol
+
+__all__ = ["ModerationDispatcher", "TelegramBotProtocol"]

--- a/bot_platform/telegram/dispatcher.py
+++ b/bot_platform/telegram/dispatcher.py
@@ -1,0 +1,33 @@
+"""Telegram dispatcher utilities that are aware of moderator chat IDs."""
+from __future__ import annotations
+
+from typing import Iterable, Protocol
+
+from bot_platform.config import Settings
+
+
+class TelegramBotProtocol(Protocol):
+    """Simplified protocol representing the interface used by the dispatcher."""
+
+    def send_message(self, chat_id: int, text: str, **kwargs: object) -> None:
+        """Send a message to the given chat."""
+
+
+class ModerationDispatcher:
+    """Dispatches Telegram messages to moderators configured in settings."""
+
+    def __init__(self, bot: TelegramBotProtocol, settings: Settings) -> None:
+        self._bot = bot
+        self._settings = settings
+
+    @property
+    def moderation_targets(self) -> Iterable[int]:
+        """Return the list of chat IDs used for moderation notifications."""
+
+        return self._settings.moderation_chat_ids
+
+    def notify_moderators(self, text: str, **kwargs: object) -> None:
+        """Send a notification message to all moderation chats."""
+
+        for chat_id in self.moderation_targets:
+            self._bot.send_message(chat_id=chat_id, text=text, **kwargs)


### PR DESCRIPTION
## Summary
- normalise moderator and administrator chat identifiers through shared helpers, supporting whitespace delimiters and enforcing a single moderator ID
- expose moderation chat targets as an immutable deduplicated sequence for downstream consumers
- refresh the sample environment file and README to document the stricter parsing rules and supported delimiters

## Testing
- python -m compileall bot_platform

------
https://chatgpt.com/codex/tasks/task_e_68d677f8d6788327b4daa05b38664189