### PR TITLE
Rework moderation chat configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Environment variables for the user bot platform.
+#
+# Copy this file to `.env` and populate the variables before starting the
+# application locally. Secrets must never be committed to version control.
+
+# Telegram bot token used to authenticate requests against the Telegram Bot API.
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+
+# Chat identifier that should receive moderator alerts (can be a user or group
+# chat). Provide exactly one numeric identifier; leave the value blank to
+# disable moderator notifications entirely.
+MODERATOR_CHAT_ID=123456789
+
+# Optional additional chats that should be informed together with the moderator
+# chat. Accepts whitespace- or comma-separated values. Non-numeric entries are
+# rejected and duplicates are ignored when dispatching notifications.
+ADMIN_CHAT_IDS=987654321,123456780

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# User Bot Platform
+
+To configure the Telegram bot, copy `.env.example` to `.env` and adjust the
+values for your deployment:
+
+- `TELEGRAM_BOT_TOKEN` – Token issued by [@BotFather](https://t.me/BotFather).
+- `MODERATOR_CHAT_ID` – Single numeric chat identifier that should receive
+  moderator notifications. Leave unset to disable moderation alerts.
+- `ADMIN_CHAT_IDS` – Optional additional chats for escalation messages. The
+  value accepts comma- or whitespace-separated identifiers. Non-numeric values
+  cause configuration to fail, and duplicates are ignored.
+
+At runtime the application loads these values through
+`bot_platform.config.Settings`. The helper exposes `Settings.moderation_chat_ids`
+which aggregates the moderator and administrator targets. The Telegram
+dispatcher (`bot_platform/telegram/dispatcher.py`) uses this helper to deliver
+notifications to every configured moderation chat.

--- a/bot_platform/__init__.py
+++ b/bot_platform/__init__.py
@@ -1,0 +1,5 @@
+"""Core package for the user bot platform."""
+
+from .config import Settings, get_settings
+
+__all__ = ["Settings", "get_settings"]

--- a/bot_platform/config.py
+++ b/bot_platform/config.py
@@ -1,0 +1,108 @@
+"""Zarządzanie konfiguracją aplikacji."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from functools import lru_cache
+import re
+from typing import Iterator, Tuple
+
+from pydantic import BaseSettings, Field, validator
+
+_CHAT_ID_SEPARATOR = re.compile(r"[,\s]+")
+
+
+class Settings(BaseSettings):
+    """Ładuje konfigurację z otoczenia wykonawczego."""
+
+    telegram_bot_token: str = Field(..., env="TELEGRAM_BOT_TOKEN")
+    moderator_chat_id: int | None = Field(default=None, env="MODERATOR_CHAT_ID")
+    admin_chat_ids: Tuple[int, ...] = Field(default_factory=tuple, env="ADMIN_CHAT_IDS")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+    @validator("moderator_chat_id", pre=True)
+    def _normalise_moderator_chat_id(cls, value: object) -> int | None:
+        ids = cls._parse_chat_ids(value, field_name="MODERATOR_CHAT_ID", allow_multiple=False)
+        return ids[0] if ids else None
+
+    @validator("admin_chat_ids", pre=True)
+    def _normalise_admin_chat_ids(cls, value: object) -> Tuple[int, ...]:
+        return cls._parse_chat_ids(value, field_name="ADMIN_CHAT_IDS", allow_multiple=True)
+
+    @property
+    def moderation_chat_ids(self) -> Tuple[int, ...]:
+        """Zwraca pełną listę czatów do powiadomień moderacyjnych."""
+
+        if self.moderator_chat_id is None:
+            return self.admin_chat_ids
+
+        unique: list[int] = [self.moderator_chat_id]
+        for chat_id in self.admin_chat_ids:
+            if chat_id not in unique:
+                unique.append(chat_id)
+        return tuple(unique)
+
+    @classmethod
+    def _parse_chat_ids(
+        cls,
+        value: object,
+        *,
+        field_name: str,
+        allow_multiple: bool,
+    ) -> Tuple[int, ...]:
+        """Przekształca dane wejściowe w krotkę identyfikatorów czatów."""
+
+        tokens = list(cls._iterate_raw_tokens(value))
+        if not tokens:
+            return ()
+
+        if not allow_multiple and len(tokens) != 1:
+            raise ValueError(f"{field_name} musi zawierać dokładnie jeden identyfikator czatu")
+
+        parsed: list[int] = []
+        for token in tokens:
+            try:
+                parsed.append(int(token))
+            except ValueError as exc:  # pragma: no cover - walidacja defensywna
+                raise ValueError(f"{field_name} musi zawierać wartości liczbowe") from exc
+
+        if allow_multiple:
+            return tuple(cls._deduplicate(parsed))
+        return tuple(parsed)
+
+    @staticmethod
+    def _iterate_raw_tokens(value: object) -> Iterator[str]:
+        if value in (None, "", [], ()):  # umożliwiamy pozostawienie pustych zmiennych
+            return iter(())
+
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return iter(())
+            return (segment for segment in _CHAT_ID_SEPARATOR.split(stripped) if segment)
+
+        if isinstance(value, Iterable):
+            return (
+                stripped
+                for item in value
+                if (stripped := str(item).strip())
+            )
+
+        return iter((str(value).strip(),))
+
+    @staticmethod
+    def _deduplicate(values: Iterable[int]) -> Iterable[int]:
+        seen: set[int] = set()
+        for value in values:
+            if value in seen:
+                continue
+            seen.add(value)
+            yield value
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Zwraca singletun z konfiguracją aplikacji."""
+
+    return Settings()

--- a/bot_platform/telegram/__init__.py
+++ b/bot_platform/telegram/__init__.py
@@ -1,0 +1,5 @@
+"""Telegram integration helpers for the user bot platform."""
+
+from .dispatcher import ModerationDispatcher, TelegramBotProtocol
+
+__all__ = ["ModerationDispatcher", "TelegramBotProtocol"]

--- a/bot_platform/telegram/dispatcher.py
+++ b/bot_platform/telegram/dispatcher.py
@@ -1,0 +1,33 @@
+"""Telegram dispatcher utilities that are aware of moderator chat IDs."""
+from __future__ import annotations
+
+from typing import Iterable, Protocol
+
+from bot_platform.config import Settings
+
+
+class TelegramBotProtocol(Protocol):
+    """Simplified protocol representing the interface used by the dispatcher."""
+
+    def send_message(self, chat_id: int, text: str, **kwargs: object) -> None:
+        """Send a message to the given chat."""
+
+
+class ModerationDispatcher:
+    """Dispatches Telegram messages to moderators configured in settings."""
+
+    def __init__(self, bot: TelegramBotProtocol, settings: Settings) -> None:
+        self._bot = bot
+        self._settings = settings
+
+    @property
+    def moderation_targets(self) -> Iterable[int]:
+        """Return the list of chat IDs used for moderation notifications."""
+
+        return self._settings.moderation_chat_ids
+
+    def notify_moderators(self, text: str, **kwargs: object) -> None:
+        """Send a notification message to all moderation chats."""
+
+        for chat_id in self.moderation_targets:
+            self._bot.send_message(chat_id=chat_id, text=text, **kwargs)


### PR DESCRIPTION
## Summary
- refresh the sample environment file to clarify moderator and admin chat configuration
- simplify Settings parsing to normalise chat identifiers and expose combined moderation targets
- update the README with guidance on configuring moderation chat destinations

## Testing
- python -m compileall bot_platform

------
https://chatgpt.com/codex/tasks/task_e_68d677f8d6788327b4daa05b38664189