### PR TITLE
Dodaj środowisko Alembic i migrację początkową

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ uvicorn bot_platform.telegram.webhooks:app --reload
 
 (For production you would configure Telegram webhooks to hit the `/telegram/{bot_token}` endpoint.)
 
+## Migracje bazy danych
+
+Projekt zawiera wstępnie skonfigurowane środowisko Alembic (`alembic.ini` oraz katalog `alembic/`). Aby zsynchronizować schemat bazy z modelami, ustaw zmienną środowiskową `DATABASE_URL` (np. `export DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/dbname`) i uruchom:
+
+```bash
+alembic upgrade head
+```
+
+Jeśli rozpoczynasz zupełnie nowy projekt i katalog `alembic/` nie istnieje, można go odtworzyć poleceniem `alembic init alembic`. W tym repozytorium nie jest to konieczne – struktura migracji jest gotowa do użycia.
+
 ## Testing
 
 Tests are not included yet. Suggested command:

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,8 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = ${DATABASE_URL}
+
+autogenerate = true
+
+[post_write_hooks]
+hooks =

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,79 @@
+"""Konfiguracja środowiska migracji Alembic."""
+from __future__ import annotations
+
+import asyncio
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from bot_platform.database import get_engine
+from bot_platform.models import Base
+
+# Alembic Config object, dostępny w pliku ini.
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Metadane modeli, wykorzystywane w trybie autogeneracji.
+target_metadata = Base.metadata
+
+
+def _get_sqlalchemy_url() -> str:
+    """Zwraca adres bazy danych z konfiguracji lub zmiennej środowiskowej."""
+    url = config.get_main_option("sqlalchemy.url")
+    if not url or url == "${DATABASE_URL}":
+        env_url = os.getenv("DATABASE_URL")
+        if not env_url:
+            raise RuntimeError(
+                "Brak konfiguracji bazy danych: ustaw zmienną środowiskową DATABASE_URL."
+            )
+        url = env_url
+    return url
+
+
+def run_migrations_offline() -> None:
+    """Wykonuje migracje w trybie offline."""
+    url = _get_sqlalchemy_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+        compare_server_default=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        compare_type=True,
+        compare_server_default=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    """Wykonuje migracje w trybie online z użyciem asynchronicznego silnika."""
+    connectable: AsyncEngine = get_engine()
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,15 @@
+"""Skrypt migracji Alembic."""
+from __future__ import annotations
+
+revision = ${repr(revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/20240521_01_initial_schema.py
+++ b/alembic/versions/20240521_01_initial_schema.py
@@ -1,0 +1,250 @@
+"""Początkowa struktura bazy danych."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# Revision identifiers, used by Alembic.
+revision = "20240521_01"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+media_type_enum = postgresql.ENUM("text", "image", "audio", name="mediatype")
+moderation_status_enum = postgresql.ENUM(
+    "pending", "approved", "rejected", name="moderationstatus"
+)
+subscription_plan_enum = postgresql.ENUM(
+    "monthly", "yearly", "free", name="subscriptionplan"
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    media_type_enum.create(bind, checkfirst=True)
+    moderation_status_enum.create(bind, checkfirst=True)
+    subscription_plan_enum.create(bind, checkfirst=True)
+
+    op.create_table(
+        "personas",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("language", sa.String(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.UniqueConstraint("name", name="uq_personas_name"),
+    )
+
+    op.create_table(
+        "admins",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("telegram_user_id", sa.Integer(), nullable=False),
+        sa.Column("username", sa.String(length=255), nullable=True),
+        sa.Column("joined_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("telegram_user_id", name="uq_admins_telegram_user_id"),
+    )
+
+    op.create_table(
+        "bots",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("token_hash", sa.String(length=128), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("persona_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["persona_id"], ["personas.id"], ondelete="RESTRICT"
+        ),
+        sa.UniqueConstraint("token_hash", name="uq_bots_token_hash"),
+    )
+
+    op.create_index(
+        "ix_bots_token_hash", "bots", ["token_hash"], unique=False
+    )
+
+    op.create_table(
+        "persona_aliases",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("persona_id", sa.Integer(), nullable=False),
+        sa.Column("alias", sa.String(length=255), nullable=False),
+        sa.Column("added_by_admin_id", sa.Integer(), nullable=True),
+        sa.Column("added_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("removed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("removed_by_admin_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["persona_id"], ["personas.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["added_by_admin_id"], ["admins.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["removed_by_admin_id"], ["admins.id"], ondelete="SET NULL"
+        ),
+        sa.UniqueConstraint("persona_id", "alias", name="uq_alias_per_persona"),
+    )
+    op.create_index("ix_alias_lookup", "persona_aliases", ["alias"], unique=False)
+
+    op.create_table(
+        "submissions",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("persona_id", sa.Integer(), nullable=False),
+        sa.Column("submitted_by_user_id", sa.Integer(), nullable=False),
+        sa.Column("submitted_chat_id", sa.Integer(), nullable=False),
+        sa.Column("media_type", media_type_enum, nullable=False),
+        sa.Column("text_content", sa.Text(), nullable=True),
+        sa.Column("file_id", sa.String(length=255), nullable=True),
+        sa.Column("file_hash", sa.LargeBinary(), nullable=True),
+        sa.Column("status", moderation_status_enum, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("decided_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("decided_by_admin_id", sa.Integer(), nullable=True),
+        sa.Column("rejection_reason", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["persona_id"], ["personas.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["decided_by_admin_id"], ["admins.id"], ondelete="SET NULL"
+        ),
+    )
+    op.create_index(
+        "ix_submission_status", "submissions", ["status"], unique=False
+    )
+    op.create_index(
+        "ix_submission_persona", "submissions", ["persona_id"], unique=False
+    )
+
+    op.create_table(
+        "quotes",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("persona_id", sa.Integer(), nullable=False),
+        sa.Column("media_type", media_type_enum, nullable=False),
+        sa.Column("text_content", sa.Text(), nullable=True),
+        sa.Column("file_id", sa.String(length=255), nullable=True),
+        sa.Column("file_hash", sa.LargeBinary(), nullable=True),
+        sa.Column("language", sa.String(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("source_submission_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["persona_id"], ["personas.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_submission_id"], ["submissions.id"], ondelete="SET NULL"
+        ),
+    )
+    op.create_index("ix_quote_persona", "quotes", ["persona_id"], unique=False)
+    op.create_index("ix_quote_language", "quotes", ["language"], unique=False)
+
+    op.create_table(
+        "moderation_actions",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("submission_id", sa.Integer(), nullable=False),
+        sa.Column("admin_id", sa.Integer(), nullable=True),
+        sa.Column("action", moderation_status_enum, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["submission_id"], ["submissions.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["admin_id"], ["admins.id"], ondelete="SET NULL"
+        ),
+    )
+
+    op.create_table(
+        "bot_chat_subscriptions",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("bot_id", sa.Integer(), nullable=False),
+        sa.Column("chat_id", sa.Integer(), nullable=False),
+        sa.Column("plan", subscription_plan_enum, nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("granted_by_admin_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["bot_id"], ["bots.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["granted_by_admin_id"], ["admins.id"], ondelete="SET NULL"
+        ),
+        sa.UniqueConstraint("bot_id", "chat_id", name="uq_bot_chat"),
+    )
+    op.create_index(
+        "ix_bot_subscription_status",
+        "bot_chat_subscriptions",
+        ["is_active"],
+        unique=False,
+    )
+
+    op.create_table(
+        "subscription_ledger",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("bot_id", sa.Integer(), nullable=False),
+        sa.Column("chat_id", sa.Integer(), nullable=True),
+        sa.Column("plan", subscription_plan_enum, nullable=False),
+        sa.Column("amount_stars", sa.Integer(), nullable=False),
+        sa.Column("transaction_id", sa.String(length=255), nullable=True),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(["bot_id"], ["bots.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        "ix_subscription_ledger_bot",
+        "subscription_ledger",
+        ["bot_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("actor_user_id", sa.Integer(), nullable=True),
+        sa.Column("actor_chat_id", sa.Integer(), nullable=True),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.CheckConstraint(
+            "length(event_type) > 0", name="ck_event_type_not_empty"
+        ),
+    )
+    op.create_index(
+        "ix_audit_event_type", "audit_logs", ["event_type"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_event_type", table_name="audit_logs")
+    op.drop_table("audit_logs")
+
+    op.drop_index("ix_subscription_ledger_bot", table_name="subscription_ledger")
+    op.drop_table("subscription_ledger")
+
+    op.drop_index(
+        "ix_bot_subscription_status", table_name="bot_chat_subscriptions"
+    )
+    op.drop_table("bot_chat_subscriptions")
+
+    op.drop_table("moderation_actions")
+
+    op.drop_index("ix_quote_language", table_name="quotes")
+    op.drop_index("ix_quote_persona", table_name="quotes")
+    op.drop_table("quotes")
+
+    op.drop_index("ix_submission_persona", table_name="submissions")
+    op.drop_index("ix_submission_status", table_name="submissions")
+    op.drop_table("submissions")
+
+    op.drop_index("ix_alias_lookup", table_name="persona_aliases")
+    op.drop_table("persona_aliases")
+
+    op.drop_index("ix_bots_token_hash", table_name="bots")
+    op.drop_table("bots")
+
+    op.drop_table("admins")
+
+    op.drop_table("personas")
+
+    bind = op.get_bind()
+    subscription_plan_enum.drop(bind, checkfirst=True)
+    moderation_status_enum.drop(bind, checkfirst=True)
+    media_type_enum.drop(bind, checkfirst=True)


### PR DESCRIPTION
## Summary
- dodano konfigurację Alembic w pliku `alembic.ini`, korzystającą ze zmiennej środowiskowej `DATABASE_URL`
- przygotowano katalog `alembic/` z konfiguracją środowiska i początkową migracją odzwierciedlającą bieżące modele
- zaktualizowano dokumentację, opisując sposób uruchamiania migracji

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d72926de8883279e644c93a9500658